### PR TITLE
Add label to search button

### DIFF
--- a/lib/rummage_phoenix/hooks/views/search_view.ex
+++ b/lib/rummage_phoenix/hooks/views/search_view.ex
@@ -50,6 +50,7 @@ defmodule Rummage.Phoenix.SearchView do
         paginate = if rummage["paginate"], do: Poison.encode!(rummage["paginate"]), else: ""
 
         button_class = Keyword.get(link_params, :button_class, "btn btn-primary")
+        button_label = Keyword.get(link_params, :button_label, "Search")
         fields = Keyword.fetch!(link_params, :fields)
 
         form_for(conn, apply(unquote(opts[:helpers]), String.to_atom("#{unquote(opts[:struct])}_path"), [conn, :index]), [as: :rummage, method: :get], fn(f) ->
@@ -63,7 +64,7 @@ defmodule Rummage.Phoenix.SearchView do
                 inner_form(s, fields, search)
               }
               end), 1) ++
-            elem(submit("Search", class: button_class), 1)
+            elem(submit(raw(button_label), class: button_class), 1)
           }
         end)
       end


### PR DESCRIPTION
When you're making a product to be consumed by english speakers it's ok
to have a hard coded "Search" label to your search button. But if you
want to attend a different language, such as brazilian portuguese or
japanese, this strategy will no longer work.

Facing that problem, I create a solution that I think is good not only
for me but for everyone using Rummage and is good to Rummage itself
because this adds more flexibility to use, helping to attract a bigger
range of users.

The change itself is not a big deal, it just pass around an label
attribute that is used as substitute of the hard coded "Search" label.
Works identical as the button class attribute which is passed in the
search_form params.