### PR TITLE
Make work with Phoenix 1.3

### DIFF
--- a/lib/rummage_phoenix/hooks/views/paginate_view.ex
+++ b/lib/rummage_phoenix/hooks/views/paginate_view.ex
@@ -96,7 +96,7 @@ defmodule Rummage.Phoenix.PaginateView do
 
     lower_limit = cond do
       page <= div(max_page_links, 2) -> 1
-      page >= (max_page - div(max_page_links, 2)) -> max_page - max_page_links + 1
+      page >= (max_page - div(max_page_links, 2)) -> Enum.max([0, max_page - max_page_links]) + 1
       true -> page - div(max_page_links, 2)
     end
 

--- a/lib/rummage_phoenix/view_resolver.ex
+++ b/lib/rummage_phoenix/view_resolver.ex
@@ -3,7 +3,7 @@ defmodule Rummage.Phoenix.ViewResolver do
     "#{view_module}"
     |> String.split(".")
     |> Enum.at(1)
-    |> (& "Elixir." <> &1 <> ".Router.Helpers").()
+    |> (& "Elixir." <> &1 <> ".Web.Router.Helpers").()
     |> String.to_atom
   end
 

--- a/lib/rummage_phoenix/view_resolver.ex
+++ b/lib/rummage_phoenix/view_resolver.ex
@@ -3,8 +3,7 @@ defmodule Rummage.Phoenix.ViewResolver do
     "#{view_module}"
     |> String.split(".")
     |> Enum.at(1)
-    |> (& "Elixir." <> &1 <> ".Web.Router.Helpers").()
-    |> String.to_atom
+    |> helpers_module
   end
 
   def make_struct_name_from_bottommost_namespace(view_module) do
@@ -15,5 +14,16 @@ defmodule Rummage.Phoenix.ViewResolver do
     |> Enum.at(0)
     |> String.downcase
     |> String.to_atom
+  end
+
+  defp helpers_module(app) do
+    [
+      "Elixir.#{app}.Web.Router.Helpers",
+      "Elixir.#{app}.Router.Helpers",
+    ]
+    |> Enum.map(&String.to_atom/1)
+    |> Enum.find(fn module ->
+      function_exported?(module, :__info__, 1)
+    end)
   end
 end


### PR DESCRIPTION
Fixes the Router Helpers path for Phoenix 1.3.

Also fixes a bug where there could be links to page 0 and page -1 if max_page_links was greater than max_page.