### PR TITLE
add 'all' to pagination links

### DIFF
--- a/lib/rummage_phoenix.ex
+++ b/lib/rummage_phoenix.ex
@@ -28,7 +28,7 @@ defmodule Rummage.Phoenix do
       2
   """
   def default_per_page do
-    config(:default_per_page, Rummage.Ecto.Config.default_per_page)
+    config(:default_per_page, Rummage.Ecto.Config.per_page)
   end
 
   @doc """

--- a/lib/rummage_phoenix/hooks/views/paginate_view.ex
+++ b/lib/rummage_phoenix/hooks/views/paginate_view.ex
@@ -23,7 +23,6 @@ defmodule Rummage.Phoenix.PaginateView do
   """
 
   use Rummage.Phoenix.ThemeAdapter
-  import Phoenix.HTML
 
   @doc """
   This macro includes the helper functions for pagination
@@ -47,12 +46,44 @@ defmodule Rummage.Phoenix.PaginateView do
       middle_page_links(conn, rummage, opts) ++
       [next_page_link(conn, rummage, opts)] ++
       [last_page_link(conn, rummage, opts)]
-      |> Enum.join("\n")
+    end
+  end
+
+  def pagination_with_all_link(conn, rummage, opts \\ []) do
+    pagination_links do
+      [first_page_link(conn, rummage, opts)] ++
+      [previous_page_link(conn, rummage, opts)] ++
+      middle_page_links(conn, rummage, opts) ++
+      [next_page_link(conn, rummage, opts)] ++
+      [last_page_link(conn, rummage, opts)] ++
+      [all_page_link(conn, rummage, opts)]
+    end
+  end
+
+  def all_page_link(conn, rummage, opts) do
+    paginate_params = rummage.paginate
+
+    per_page = paginate_params.per_page
+    label = opts[:all_label] || "All"
+
+    case per_page == -1 do
+      true -> page_link "#", :disabled, do: label
+      false ->
+        page_link index_path(opts, [conn, :index,
+          transform_params(rummage, -1, 1, opts)]), do: label
     end
   end
 
   # def per_page_link(conn, rummage, opts \\ []) do
-  #   form_for(conn, index_path(opts, [conn, :index]))
+  #   import Phoenix.HTML.Form
+
+  #   paginate_params = rummage.paginate
+
+  #   form_for conn, index_path(opts, [conn, :index]), [as: :params, method: :get], fn(form) ->
+  #     input = number_input(form, :per_page, value: paginate_params.per_page)
+  #     submit = submit("Set Per Page", class: "btn btn-default")
+  #     [input, submit]
+  #   end
   # end
 
   defp first_page_link(conn, rummage, opts) do

--- a/lib/rummage_phoenix/hooks/views/sort_view.ex
+++ b/lib/rummage_phoenix/hooks/views/sort_view.ex
@@ -25,7 +25,6 @@ defmodule Rummage.Phoenix.SortView do
   """
 
   use Rummage.Phoenix.ThemeAdapter
-  import Phoenix.HTML
 
   @doc """
   This macro includes the helpers functions for sorting.
@@ -50,26 +49,31 @@ defmodule Rummage.Phoenix.SortView do
     desc_icon = Keyword.get(opts, :desc_icon)
     desc_text = Keyword.get(opts, :desc_text, "↓")
 
-    text = if sort_params.name == Atom.to_string(field) do
+    # Drop pagination unless we're showing the entire result set
+    rummage_params = if rummage.params.paginate && rummage.params.paginate.per_page == -1 do
+      rummage.params
+    else
+      rummage.params
+      |> Map.drop([:paginate])
+    end
+
+    if sort_params.name == Atom.to_string(field) do
       case sort_params.order do
         "asc" ->
-          rummage_params = rummage.params
-          |> Map.drop([:paginate])
+          rummage_params = rummage_params
           |> Map.put(:sort, %{name: field, order: "desc"})
 
           url = index_path(opts, [conn, :index, %{rummage: rummage_params}])
           sort_text_or_image(url, [img: desc_icon, text: desc_text], name)
         "desc" ->
-          rummage_params = rummage.params
-          |> Map.drop([:paginate])
+          rummage_params = rummage_params
           |> Map.put(:sort, %{name: field, order: "asc"})
 
           url = index_path(opts, [conn, :index, %{rummage: rummage_params}])
           sort_text_or_image(url, [img: asc_icon, text: asc_text], name)
       end
     else
-      rummage_params = rummage.params
-      |> Map.drop([:paginate])
+      rummage_params = rummage_params
       |> Map.put(:sort, %{name: field, order: "asc"})
 
       url = index_path(opts, [conn, :index, %{rummage: rummage_params}])

--- a/lib/rummage_phoenix/theme_adapters/bootstrap_adapter.ex
+++ b/lib/rummage_phoenix/theme_adapters/bootstrap_adapter.ex
@@ -1,52 +1,46 @@
 defmodule Rummage.Phoenix.BootstrapAdapter do
   defmacro pagination_links(do: expression) do
     quote do
-      raw """
-      <nav aria-label="...">
-        <ul class="pagination">
-          #{unquote(expression)}
-        </ul>
-      </nav>
-      """
+      Phoenix.HTML.Tag.content_tag :nav, ["aria-lablel": "..."] do
+        Phoenix.HTML.Tag.content_tag :ul, [class: "pagination"] do
+          unquote(expression)
+        end
+      end
     end
   end
 
   defmacro page_link(url, :disabled, do: text) do
     quote do
-      """
-      <li class="page-item disabled">
-        <a class="page-link" href="#{unquote(url)}" tabindex="-1">
-          #{unquote(text)}
-        </a>
-      </li>
-      """
+      Phoenix.HTML.Tag.content_tag :li, [class: "page-item disabled"] do
+        Phoenix.HTML.Link.link [to: unquote(url), class: "page-link", tabindex: -1] do
+          unquote(text)
+        end
+      end
     end
   end
 
   defmacro page_link(url, :active, do: text) do
     quote do
-      """
-      <li class="page-item active">
-        <a class="page-link" href="#{unquote(url)}">
-          #{unquote(text)}
-          <span class="sr-only">
-            (current)
-          </span>
-        </a>
-      </li>
-      """
+      Phoenix.HTML.Tag.content_tag :li, [class: "page-item active"] do
+        Phoenix.HTML.Link.link [to: unquote(url), class: "page-link"] do
+          [
+            Phoenix.HTML.html_escape(unquote(text)),
+            Phoenix.HTML.Tag.content_tag :span, [class: "sr-only"] do
+              "(current)"
+            end
+          ]
+        end
+      end
     end
   end
 
   defmacro page_link(url, do: text) do
     quote do
-      """
-      <li class="page-item">
-        <a class="page-link" href="#{unquote(url)}">
-          #{unquote(text)}
-        </a>
-      </li>
-      """
+      Phoenix.HTML.Tag.content_tag :li, [class: "page-item"] do
+        Phoenix.HTML.Link.link [to: unquote(url), class: "page-link"] do
+          unquote(text)
+        end
+      end
     end
   end
 

--- a/lib/rummage_phoenix/view.ex
+++ b/lib/rummage_phoenix/view.ex
@@ -24,6 +24,11 @@ defmodule Rummage.Phoenix.View do
         PaginateView.pagination_link(conn, rummage, opts ++ [struct: struct(), helpers: helpers()])
       end
 
+      # TODO: This doesn't scale well.
+      def pagination_with_all_link(conn, rummage, opts \\ []) do
+        PaginateView.pagination_with_all_link(conn, rummage, opts ++ [struct: struct(), helpers: helpers()])
+      end
+
       def sort_link(conn, rummage, field) do
         sort_link(conn, rummage, field, Phoenix.Naming.humanize(field), [])
       end


### PR DESCRIPTION
Also fixes some warnings, and uses phoenix helpers instead of raw HTML for pagination links.

I'm not a fan of the new helper. I'd prefer to configure the old one, but I wanted to do it globally, and not per call. Thoughts on how to accomplish that?