### PR TITLE
allow a path for sort links

### DIFF
--- a/lib/rummage_phoenix/hooks/views/sort_view.ex
+++ b/lib/rummage_phoenix/hooks/views/sort_view.ex
@@ -40,6 +40,7 @@ defmodule Rummage.Phoenix.SortView do
   ```elixir
   <%= sort_link @conn, @rummage, field, "Name" %>
   <%= sort_link @conn, {@rummage, :rummage_key}, field, "Name" %>
+  <%= sort_link @conn, {@rummage, :rummage_key}, field, "Name", path: &(something_path_path(@conn, :show, @something, &1)) %>
   ```
   """
   def sort_link(conn, {rummage, rummage_key}, field, name, opts) do
@@ -57,6 +58,7 @@ defmodule Rummage.Phoenix.SortView do
     desc_icon = Keyword.get(opts, :desc_icon)
     desc_text = Keyword.get(opts, :desc_text, "↓")
     rummage_key = Keyword.get(opts, :rummage_key, :rummage)
+    path = Keyword.get(opts, :path, index_path_fn(conn, opts))
 
     # Drop pagination unless we're showing the entire result set
     rummage_params = if rummage.params.paginate && rummage.params.paginate.per_page == -1 do
@@ -72,28 +74,30 @@ defmodule Rummage.Phoenix.SortView do
           rummage_params = rummage_params
           |> Map.put(:sort, %{name: field, order: "desc"})
 
-          url = index_path(opts, [conn, :index, %{rummage_key => rummage_params}])
+          url = path.(%{rummage_key => rummage_params})
           sort_text_or_image(url, [img: desc_icon, text: desc_text], name)
         "desc" ->
           rummage_params = rummage_params
           |> Map.put(:sort, %{name: field, order: "asc"})
 
-          url = index_path(opts, [conn, :index, %{rummage_key => rummage_params}])
+          url = path.(%{rummage_key => rummage_params})
           sort_text_or_image(url, [img: asc_icon, text: asc_text], name)
       end
     else
       rummage_params = rummage_params
       |> Map.put(:sort, %{name: field, order: "asc"})
 
-      url = index_path(opts, [conn, :index, %{rummage_key => rummage_params}])
+      url = path.(%{rummage_key => rummage_params})
       sort_text_or_image(url, [], name)
     end
   end
 
-  defp index_path(opts, params) do
+  def index_path_fn(conn, opts) do
     helpers = opts[:helpers]
     path_function_name = String.to_atom("#{opts[:struct]}_path")
 
-    apply(helpers, path_function_name, params)
+    fn(params) ->
+      apply(helpers, path_function_name, [conn, :index, params])
+    end
   end
 end

--- a/lib/rummage_phoenix/hooks/views/sort_view.ex
+++ b/lib/rummage_phoenix/hooks/views/sort_view.ex
@@ -40,7 +40,7 @@ defmodule Rummage.Phoenix.SortView do
   ```elixir
   <%= sort_link @conn, @rummage, field, "Name" %>
   <%= sort_link @conn, {@rummage, :rummage_key}, field, "Name" %>
-  <%= sort_link @conn, {@rummage, :rummage_key}, field, "Name", path: &(something_path_path(@conn, :show, @something, &1)) %>
+  <%= sort_link @conn, @rummage, field, "Name", path: &(something_path(@conn, :show, @something, &1)) %>
   ```
   """
   def sort_link(conn, {rummage, rummage_key}, field, name, opts) do


### PR DESCRIPTION
Addresses: https://github.com/aditya7iyengar/rummage_phoenix/issues/65

I felt the options were a little verbose (repeated for each sort_link)

```
<%= sort_link @conn, @rummage, :name, "Name", path: &(something_path(@conn, :show, @something, &1)) %>
```

so in my view I made a helper:

```
def show_sort_link(something, conn, rummage, field, name) do
  sort_link(conn, rummage, field, name, path: &(something_path(conn, :show, something, &1)))
end
```

and then the call became

```
<%= show_sort_link @something, @conn, @rummage, :name, "Name" %>
```